### PR TITLE
Fix line counting

### DIFF
--- a/src/filechooser/filechooser.c
+++ b/src/filechooser/filechooser.c
@@ -54,8 +54,8 @@ static int exec_filechooser(void *data, bool writing, bool multiple, bool direct
         cr = getc(fp);
         if (cr == '\n') {
             num_lines++;
+            cr = getc(fp);
         }
-        cr = getc(fp);
         if (ferror(fp)) {
             return 1;
         }


### PR DESCRIPTION
Instead of skipping every other char (and thus possibly newlines), skip only immediately after a newline.