### PR TITLE
fix: cast EOF to char

### DIFF
--- a/src/filechooser/filechooser.c
+++ b/src/filechooser/filechooser.c
@@ -59,7 +59,7 @@ static int exec_filechooser(void *data, bool writing, bool multiple, bool direct
         if (ferror(fp)) {
             return 1;
         }
-    } while (cr != EOF);
+    } while (cr != (char)EOF);
     rewind(fp);
 
     if (num_lines == 0) {


### PR DESCRIPTION
Fixes build on aarch64 :

```
ninja: Entering directory `build'
[1/2] Compiling C object xdg-desktop-portal-termfilechooser.p/src_filechooser_filechooser.c.o
FAILED: xdg-desktop-portal-termfilechooser.p/src_filechooser_filechooser.c.o
cc -Ixdg-desktop-portal-termfilechooser.p -I. -I.. -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -Wno-missing-braces -Wno-missing-field-initializers -Wno-unused-parameter -D_POSIX_C_SOURCE=200809L '-DSYSCONFDIR="/usr/local/etc"' -DHAVE_LIBSYSTEMD=1 -MD -MQ xdg-desktop-portal-termfilechooser.p/src_filechooser_filechooser.c.o -MF xdg-desktop-portal-termfilechooser.p/src_filechooser_filechooser.c.o.d -o xdg-desktop-portal-termfilechooser.p/src_filechooser_filechooser.c.o -c ../src/filechooser/filechooser.c
../src/filechooser/filechooser.c: In function ‘exec_filechooser’:
../src/filechooser/filechooser.c:62:17: error: comparison is always true due to limited range of data type [-Werror=type-limits]
   62 |     } while (cr != EOF);
      |                 ^~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```