### PR TITLE
Don't hardcode kitty & ranger

### DIFF
--- a/contrib/fzf-wrapper.sh
+++ b/contrib/fzf-wrapper.sh
@@ -25,7 +25,7 @@ save="$3"
 path="$4"
 out="$5"
 
-termcmd="${TERMCMD:-/usr/bin/kitty}"
+termcmd="${TERMCMD:-$(command -v kitty)}"
 
 if [ "$save" = "1" ]; then
     cmd="dialog --yesno \"Save to \"$path\"?\" 0 0 && ( printf '%s' \"$path\" > $out ) || ( printf '%s' 'Input path to write to: ' && read input && printf '%s' \"\$input\" > $out)"

--- a/contrib/ranger-wrapper.sh
+++ b/contrib/ranger-wrapper.sh
@@ -26,7 +26,7 @@ path="$4"
 out="$5"
 
 cmd="/usr/bin/ranger"
-termcmd="${TERMCMD:-/usr/bin/kitty}"
+termcmd="${TERMCMD:-$(command -v kitty)}"
 
 if [ "$save" = "1" ]; then
     set -- --choosefile="$out" --cmd='echo Select save path (see tutorial in preview pane; try pressing zv or zp if no preview)' "$path"

--- a/contrib/ranger-wrapper.sh
+++ b/contrib/ranger-wrapper.sh
@@ -25,7 +25,7 @@ save="$3"
 path="$4"
 out="$5"
 
-cmd="/usr/bin/ranger"
+cmd="$(command -v ranger)"
 termcmd="${TERMCMD:-$(command -v kitty)}"
 
 if [ "$save" = "1" ]; then


### PR DESCRIPTION
Hardcoding `/usr/bin/kitty` and `/usr/bin/ranger` breaks on non-FHS compliant Linux distributions, like NixOS.

This PR uses `command -v kitty` which is part of POSIX sh and returns the pathname or command executed by the shell. On Arch Linux this'd be `/usr/bin/kitty` and on my system it's `/run/current-system/sw/bin/kitty`.